### PR TITLE
Darkened icon gradient for better readability

### DIFF
--- a/global.css
+++ b/global.css
@@ -141,7 +141,7 @@ h1,h3,p {
 .api-icon {
   font-size: 3rem;
   margin-bottom: 20px;
-  background: linear-gradient(to right, #00f7ff, #ff0099);
+  background: linear-gradient(to right, #12c4ca, #ff0099);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 }


### PR DESCRIPTION
Updated the gradient color used for Font Awesome icons in the `.api-icon` class within the `global.css` stylesheet. Previously, the icon text had a very bright and vibrant gradient using:

```css
background: linear-gradient(to right, #00f7ff, #ff0099);
```

This combination, while visually striking, appeared too neon for the overall tone and design of the website. To achieve a more professional and darker aesthetic while maintaining the gradient look, I changed the first color stop (`#00f7ff`) to a deeper shade of teal — `#12c4ca`. The second color stop (`#ff0099`) remains unchanged to retain a hint of vibrant contrast.

The updated gradient now looks like this:

```css
background: linear-gradient(to right, #12c4ca, #ff0099);
```

This subtle adjustment results in a more balanced and visually appealing icon style that blends better with the rest of the site's theme without being overly flashy.

This solves #5 